### PR TITLE
Fixed #255: allow recreation of an order

### DIFF
--- a/manager/manager/models.py
+++ b/manager/manager/models.py
@@ -393,9 +393,9 @@ class Configuration(models.Model):
         ]
 
     @classmethod
-    def get_or_none(cls, id):
+    def get_or_none(cls, aid):
         try:
-            return cls.objects.get(id=id)
+            return cls.objects.get(id=aid)
         except cls.DoesNotExist:
             return None
 
@@ -980,7 +980,7 @@ class Order(models.Model):
 
     @staticmethod
     def status_from_statuses(statuses):
-        if not isinstance(statuses, list) or not len(statuses):
+        if not isinstance(statuses, list) or not statuses:
             return Order.FAILED
 
         status = statuses[-1].get("status")
@@ -1025,7 +1025,7 @@ class Order(models.Model):
                         a=order.created_by.organization.units,
                     )
                 )
-            elif order.created_by.is_limited:
+            if order.created_by.is_limited:
                 # remove units from org
                 order.created_by.organization.units -= order.units
                 order.created_by.organization.save()

--- a/manager/manager/templates/all_orders-detail.html
+++ b/manager/manager/templates/all_orders-detail.html
@@ -2,6 +2,11 @@
 {% load manager %}
 
 {% block content %}
+{% if orderdata.can_recreate %}<a href="{% url 'all-orders-recreate' order_id=orderdata.id %}"
+                                  class="btn btn-sm btn-warning"
+                                  data-toggle="confirmation"
+                                  data-title="Create a new identical order?"
+                                  style="float:right;">re-create</a>{% endif %}
 <h3>Order #<code>{{ orderdata.id }}</code></h3>
 {% include "order_detail.html" with orderdata=orderdata %}
 {% endblock %}

--- a/manager/manager/urls.py
+++ b/manager/manager/urls.py
@@ -94,6 +94,11 @@ urlpatterns = (
             name="order_log",
         ),
         path(
+            "all-orders/<str:order_id>/recreate",
+            all_orders.recreate,
+            name="all-orders-recreate",
+        ),
+        path(
             "all-orders/<str:order_id>/delete",
             all_orders.delete,
             name="all-orders-delete",


### PR DESCRIPTION
This allows the recreation of an existing order under certain conditions:
- Orders marked as FAILED and CANCELED can be recreated
- IN_PROGRESS order can only be recreated if in `pending_expiry` substatus
Other IN_PROGRESS orders have no reason to be recreated. Should one want to recreate it
it must be canceled before.

COMPLETED and IN_PROGRESS Orders, when recreated skip the units decreasal
as the user would have already been charged for that order.

Recreation is done via a `re-create` button on the Order detail from the `/all-orders` list.
There's a UI confirmation after click on that button.

Recreation is thus reserbed to cardshop admin and should be used we caution.
There is no ability to customize anything from the Order. Should anything be changed, one
can create a new order.

Fixed #255 @Popolechien 